### PR TITLE
Remove zigbee-herdsman-converters/lib/extend to support Zigbee2mqtt 1.36.1

### DIFF
--- a/ZM10224gNEW2.2.js
+++ b/ZM10224gNEW2.2.js
@@ -2,7 +2,6 @@ const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
 const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const e = exposes.presets;
 const ea = exposes.access;
 const legacy = require('zigbee-herdsman-converters/lib/legacy');

--- a/ts0601_radar_X75-X25-230705.js
+++ b/ts0601_radar_X75-X25-230705.js
@@ -2,7 +2,6 @@ const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
 const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const e = exposes.presets;
 const ea = exposes.access;
 const tuya = require('zigbee-herdsman-converters/lib/tuya');

--- a/wenzhi_tuya_M100-230908.js
+++ b/wenzhi_tuya_M100-230908.js
@@ -3,7 +3,6 @@ const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
 const legacy = require('zigbee-herdsman-converters/lib/legacy');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const ota = require('zigbee-herdsman-converters/lib/ota');
 const tuya = require('zigbee-herdsman-converters/lib/tuya');
 const utils = require('zigbee-herdsman-converters/lib/utils');

--- a/zmzn24g.NEW.js
+++ b/zmzn24g.NEW.js
@@ -2,7 +2,6 @@ const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
 const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const e = exposes.presets;
 const ea = exposes.access;
 const legacy = require('zigbee-herdsman-converters/lib/legacy');

--- a/zmzn24g.js
+++ b/zmzn24g.js
@@ -2,7 +2,6 @@ const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
 const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
 const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
 const e = exposes.presets;
 const ea = exposes.access;
 const legacy = require('zigbee-herdsman-converters/lib/legacy');


### PR DESCRIPTION
Zigbee2mqtt has removed changed the `zigbee-herdsman-converters/lib/extend'` external converter which breaks the converters. I've removed this const to fix the issue and verified this fixes the issue for on my install `ts0601_radar_X75-X25-230705.js` and `wenzhi_tuya_M100-230908.js`. For more info about the issue see https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.36.1.